### PR TITLE
Evita conflito do plugin jQuery Mask com terceiros

### DIFF
--- a/assets/auge_masks.js
+++ b/assets/auge_masks.js
@@ -1,18 +1,21 @@
-jQuery(document).ready(function(){
+jAuge = jQuery.noConflict();
+jAuge.fn.as_mask = jQuery.fn.mask;
 
-	jQuery(".as_mask_zip_code").mask('00000-000',{placeholder: "_____-___"});
-	jQuery(".as_mask_date").mask('00/00/0000',{placeholder: "00/00/0000"});
-	jQuery(".as_mask_small_qtd").mask('000.000',{reverse: true});
-	jQuery(".as_mask_money").mask('000.000,00',{reverse: true});
-	jQuery(".as_mask_percentage").mask('000,00',{reverse: true});
-	jQuery(".as_mask_cnpj").mask('00.000.000/0000-00',{placeholder: "00.000.000/0000-00"});
-	jQuery(".as_mask_cpf").mask('000.000.000-00',{placeholder: "000.000.000-00"});
-	jQuery(".as_mask_bank_agency").mask('00000-0',{placeholder: "00000-0",reverse:true});
-	jQuery(".as_mask_bank_account").mask('000.000.000',{placeholder: "000.000.000"});
-	jQuery(".as_mask_bank_account_extended").mask('0.000.000.000-0',{placeholder: "0.000.000.000-0",reverse:true});
-	jQuery(".as_mask_bank_digit").mask('0',{placeholder: "0"});
-	jQuery(".as_mask_phone_prefix").mask('00',{placeholder: "00"});
-	jQuery(".as_mask_phone_number").mask('Z0000-0000',{
+jAuge(document).ready(function(){
+
+	jAuge(".as_mask_zip_code").as_mask('00000-000',{placeholder: "_____-___"});
+	jAuge(".as_mask_date").as_mask('00/00/0000',{placeholder: "00/00/0000"});
+	jAuge(".as_mask_small_qtd").as_mask('000.000',{reverse: true});
+	jAuge(".as_mask_money").as_mask('000.000,00',{reverse: true});
+	jAuge(".as_mask_percentage").as_mask('000,00',{reverse: true});
+	jAuge(".as_mask_cnpj").as_mask('00.000.000/0000-00',{placeholder: "00.000.000/0000-00"});
+	jAuge(".as_mask_cpf").as_mask('000.000.000-00',{placeholder: "000.000.000-00"});
+	jAuge(".as_mask_bank_agency").as_mask('00000-0',{placeholder: "00000-0",reverse:true});
+	jAuge(".as_mask_bank_account").as_mask('000.000.000',{placeholder: "000.000.000"});
+	jAuge(".as_mask_bank_account_extended").as_mask('0.000.000.000-0',{placeholder: "0.000.000.000-0",reverse:true});
+	jAuge(".as_mask_bank_digit").as_mask('0',{placeholder: "0"});
+	jAuge(".as_mask_phone_prefix").as_mask('00',{placeholder: "00"});
+	jAuge(".as_mask_phone_number").as_mask('Z0000-0000',{
 		reverse: true,
 		placeholder: "0000-0000",
 		translation: {
@@ -21,7 +24,7 @@ jQuery(document).ready(function(){
 			}
 		}
 	}); 
-	jQuery(".as_mask_full_phone").mask('(00) Z0000-0000',{
+	jAuge(".as_mask_full_phone").as_mask('(00) Z0000-0000',{
 		reverse: false,
 		placeholder: "(00) 0000-0000",
 		translation: {


### PR DESCRIPTION
Existem plugins WP que utilizam outros plugins jQuery diferentes do jQuery Mask e que também criam a função `jQuery.mask()`

Este commit utiliza o método `jQuery.noConflict()` para criar uma cópia do objeto `jQuery` original. Além disso, copia a função `mask()` para `as_mask()` e utiliza tanto o objeto quanto a função copiados para evitar conflito.